### PR TITLE
checkpoint_demux branch

### DIFF
--- a/baseDmux/data/report/report_demultiplex.Rmd
+++ b/baseDmux/data/report/report_demultiplex.Rmd
@@ -26,14 +26,10 @@ if (!requireNamespace("dplyr", quietly = TRUE)) install.packages('dplyr', repos 
 if (!requireNamespace("stringr", quietly = TRUE)) install.packages('stringr', repos = "https://cloud.r-project.org")
 if (!requireNamespace("S4Vectors", quietly = TRUE)) install.packages('S4Vectors', repos = "https://cloud.r-project.org")
 # if (!requireNamespace("parallel", quietly = TRUE)) install.packages('parallel', repos = "https://cloud.r-project.org")
-if (!requireNamespace("Biostrings", quietly = TRUE)) {
-  if (!requireNamespace("BiocManager", quietly = TRUE)) install.packages("BiocManager", repos = "https://cloud.r-project.org")
-  BiocManager::install("Biostrings", update = F, ask = F)
-}
-if (!requireNamespace("qckitfastq", quietly = TRUE)) {
-  if (!requireNamespace("BiocManager", quietly = TRUE)) install.packages("BiocManager", repos = "https://cloud.r-project.org")
-  BiocManager::install("qckitfastq")
-}
+if (!requireNamespace("BiocManager", quietly = TRUE)) install.packages("BiocManager", repos = "https://cloud.r-project.org")
+if (!requireNamespace("Biostrings", quietly = TRUE)) BiocManager::install("Biostrings", update = F, ask = F)
+if (!requireNamespace("qckitfastq", quietly = TRUE)) BiocManager::install("qckitfastq", update = F, ask = F)
+
 
 
 


### PR DESCRIPTION
potential to run porechop/filtlong for each barcode.
it works in dryrun, but the R script for get_reads_by_genome will need to be adapted.
just to keep this work in a separate branch ...